### PR TITLE
fix: update dependencies that don't break jsii

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: install
         run: npm ci
       - name: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 16
+      - name: Use Node.js 18
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       - name: install
         run: npm ci
       - name: release

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,37 +13,36 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "aws-sdk": "^2.1074.0",
-        "aws-xray-sdk-core": "^3.3.1"
+        "aws-sdk": "^2.1318.0",
+        "aws-xray-sdk-core": "^3.4.1"
       },
       "devDependencies": {
-        "@commitlint/cli": "^17.2.0",
-        "@commitlint/config-conventional": "^17.2.0",
-        "@semantic-release/changelog": "^6.0.1",
+        "@commitlint/cli": "^17.4.4",
+        "@commitlint/config-conventional": "^17.4.4",
+        "@semantic-release/changelog": "^6.0.2",
         "@semantic-release/exec": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
-        "@types/aws-lambda": "^8.10.108",
+        "@types/aws-lambda": "^8.10.110",
         "@types/jest": "^27.5.2",
-        "@types/node": "^18.11.9",
-        "@types/prettier": "2.6.0",
-        "@typescript-eslint/eslint-plugin": "^5.42.0",
-        "@typescript-eslint/parser": "^5.42.0",
-        "aws-cdk-lib": "2.50.0",
-        "constructs": "^10.0.0",
-        "eslint": "^8.26.0",
-        "husky": "^8.0.1",
+        "@types/node": "18.11.19",
+        "@typescript-eslint/eslint-plugin": "^5.52.0",
+        "@typescript-eslint/parser": "^5.52.0",
+        "aws-cdk-lib": "2.65.0",
+        "constructs": "10.0.0",
+        "eslint": "^8.34.0",
+        "husky": "^8.0.3",
         "is-ci": "^3.0.1",
         "jest": "^27.5.1",
-        "jsii": "^1.70.0",
-        "jsii-pacmak": "^1.70.0",
-        "jsii-release": "^0.2.515",
+        "jsii": "^1.75.0",
+        "jsii-pacmak": "^1.75.0",
+        "jsii-release": "^0.2.598",
         "mocked-env": "^1.3.5",
-        "semantic-release": "^19.0.5",
-        "ts-jest": "^27.1.4",
-        "typescript": "~3.9.7"
+        "semantic-release": "^20.1.0",
+        "ts-jest": "^27.1.5",
+        "typescript": "~4.9.5"
       },
       "peerDependencies": {
-        "aws-cdk-lib": "2.50.0",
+        "aws-cdk-lib": "2.65.0",
         "constructs": "^10.0.0"
       }
     },
@@ -59,6 +58,24 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.72",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.72.tgz",
+      "integrity": "sha512-7Qo7fkvodB8TUncfYPH+XLVFybt7AWKzLg7HWLT/GBrv9mZ3Iwf9Zq1YNoVqHEaNnqd9rnTrWjoAoDIOB0pZeg==",
+      "dev": true
+    },
+    "node_modules/@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
+      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==",
+      "dev": true
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.61",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.61.tgz",
+      "integrity": "sha512-SZZk/NtuAGHnPZV1egzrBu90zNrwvERfAOB1P6WxLkK8vbbi7pyumBpUXQ5Gxz4WhYHrmixSO/i7eBUZ2FAM8Q==",
+      "dev": true
     },
     "node_modules/@aws-sdk/service-error-classification": {
       "version": "3.208.0",
@@ -639,18 +656,18 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.2.0.tgz",
-      "integrity": "sha512-kd1zykcrjIKyDRftWW1E1TJqkgzeosEkv1BiYPCdzkb/g/3BrfgwZUHR1vg+HO3qKUb/0dN+jNXArhGGAHpmaQ==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.4.4.tgz",
+      "integrity": "sha512-HwKlD7CPVMVGTAeFZylVNy14Vm5POVY0WxPkZr7EXLC/os0LH/obs6z4HRvJtH/nHCMYBvUBQhGwnufKfTjd5g==",
       "dev": true,
       "dependencies": {
-        "@commitlint/format": "^17.0.0",
-        "@commitlint/lint": "^17.2.0",
-        "@commitlint/load": "^17.2.0",
-        "@commitlint/read": "^17.2.0",
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/format": "^17.4.4",
+        "@commitlint/lint": "^17.4.4",
+        "@commitlint/load": "^17.4.4",
+        "@commitlint/read": "^17.4.4",
+        "@commitlint/types": "^17.4.4",
         "execa": "^5.0.0",
-        "lodash": "^4.17.19",
+        "lodash.isfunction": "^3.0.9",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
         "yargs": "^17.0.0"
@@ -704,9 +721,9 @@
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.2.0.tgz",
-      "integrity": "sha512-g5hQqRa80f++SYS233dbDSg16YdyounMTAhVcmqtInNeY/GF3aA4st9SVtJxpeGrGmueMrU4L+BBb+6Vs5wrcg==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.4.tgz",
+      "integrity": "sha512-u6ztvxqzi6NuhrcEDR7a+z0yrh11elY66nRrQIpqsqW6sZmpxYkDLtpRH8jRML+mmxYQ8s4qqF06Q/IQx5aJeQ==",
       "dev": true,
       "dependencies": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
@@ -716,12 +733,12 @@
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.1.0.tgz",
-      "integrity": "sha512-Q1rRRSU09ngrTgeTXHq6ePJs2KrI+axPTgkNYDWSJIuS1Op4w3J30vUfSXjwn5YEJHklK3fSqWNHmBhmTR7Vdg==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.4.4.tgz",
+      "integrity": "sha512-bi0+TstqMiqoBAQDvdEP4AFh0GaKyLFlPPEObgI29utoKEYoPQTvF0EYqIwYYLEoJYhj5GfMIhPHJkTJhagfeg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/types": "^17.4.4",
         "ajv": "^8.11.0"
       },
       "engines": {
@@ -729,34 +746,38 @@
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
-      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.4.4.tgz",
+      "integrity": "sha512-AHsFCNh8hbhJiuZ2qHv/m59W/GRE9UeOXbkOqxYMNNg9pJ7qELnFcwj5oYpa6vzTSHtPGKf3C2yUFNy1GGHq6g==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.19"
+        "@commitlint/types": "^17.4.4",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
       },
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
-      "integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.4.0.tgz",
+      "integrity": "sha512-LIgYXuCSO5Gvtc0t9bebAMSwd68ewzmqLypqI2Kke1rqOqqDbMpYcYfoPfFlv9eyLIh4jocHWwCK5FS7z9icUA==",
       "dev": true,
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.0.0.tgz",
-      "integrity": "sha512-MZzJv7rBp/r6ZQJDEodoZvdRM0vXu1PfQvMTNWFb8jFraxnISMTnPBWMMjr2G/puoMashwaNM//fl7j8gGV5lA==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.4.4.tgz",
+      "integrity": "sha512-+IS7vpC4Gd/x+uyQPTAt3hXs5NxnkqAZ3aqrHd5Bx/R9skyCAWusNlNbw3InDbAK6j166D9asQM8fnmYIa+CXQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/types": "^17.4.4",
         "chalk": "^4.1.0"
       },
       "engines": {
@@ -764,22 +785,22 @@
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.2.0.tgz",
-      "integrity": "sha512-rgUPUQraHxoMLxiE8GK430HA7/R2vXyLcOT4fQooNrZq9ERutNrP6dw3gdKLkq22Nede3+gEHQYUzL4Wu75ndg==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.4.4.tgz",
+      "integrity": "sha512-Y3eo1SFJ2JQDik4rWkBC4tlRIxlXEFrRWxcyrzb1PUT2k3kZ/XGNuCDfk/u0bU2/yS0tOA/mTjFsV+C4qyACHw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^17.0.0",
-        "semver": "7.3.7"
+        "@commitlint/types": "^17.4.4",
+        "semver": "7.3.8"
       },
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/is-ignored/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -792,35 +813,37 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.2.0.tgz",
-      "integrity": "sha512-N2oLn4Dj672wKH5qJ4LGO+73UkYXGHO+NTVUusGw83SjEv7GjpqPGKU6KALW2kFQ/GsDefSvOjpSi3CzWHQBDg==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.4.tgz",
+      "integrity": "sha512-qgkCRRFjyhbMDWsti/5jRYVJkgYZj4r+ZmweZObnbYqPUl5UKLWMf9a/ZZisOI4JfiPmRktYRZ2JmqlSvg+ccw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/is-ignored": "^17.2.0",
-        "@commitlint/parse": "^17.2.0",
-        "@commitlint/rules": "^17.2.0",
-        "@commitlint/types": "^17.0.0"
+        "@commitlint/is-ignored": "^17.4.4",
+        "@commitlint/parse": "^17.4.4",
+        "@commitlint/rules": "^17.4.4",
+        "@commitlint/types": "^17.4.4"
       },
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.2.0.tgz",
-      "integrity": "sha512-HDD57qSqNrk399R4TIjw31AWBG8dBjNj1MrDKZKmC/wvimtnIFlqzcu1+sxfXIOHj/+M6tcMWDtvknGUd7SU+g==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.4.4.tgz",
+      "integrity": "sha512-z6uFIQ7wfKX5FGBe1AkOF4l/ShOQsaa1ml/nLMkbW7R/xF8galGS7Zh0yHvzVp/srtfS0brC+0bUfQfmpMPFVQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^17.1.0",
-        "@commitlint/execute-rule": "^17.0.0",
-        "@commitlint/resolve-extends": "^17.1.0",
-        "@commitlint/types": "^17.0.0",
-        "@types/node": "^14.0.0",
+        "@commitlint/config-validator": "^17.4.4",
+        "@commitlint/execute-rule": "^17.4.0",
+        "@commitlint/resolve-extends": "^17.4.4",
+        "@commitlint/types": "^17.4.4",
+        "@types/node": "*",
         "chalk": "^4.1.0",
-        "cosmiconfig": "^7.0.0",
+        "cosmiconfig": "^8.0.0",
         "cosmiconfig-typescript-loader": "^4.0.0",
-        "lodash": "^4.17.19",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0",
         "resolve-from": "^5.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.6.4"
@@ -829,41 +852,22 @@
         "node": ">=v14"
       }
     },
-    "node_modules/@commitlint/load/node_modules/@types/node": {
-      "version": "14.18.33",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-      "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
-      "dev": true
-    },
-    "node_modules/@commitlint/load/node_modules/typescript": {
-      "version": "4.8.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@commitlint/message": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.2.0.tgz",
-      "integrity": "sha512-/4l2KFKxBOuoEn1YAuuNNlAU05Zt7sNsC9H0mPdPm3chOrT4rcX0pOqrQcLtdMrMkJz0gC7b3SF80q2+LtdL9Q==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.4.2.tgz",
+      "integrity": "sha512-3XMNbzB+3bhKA1hSAWPCQA3lNxR4zaeQAQcHj0Hx5sVdO6ryXtgUBGGv+1ZCLMgAPRixuc6en+iNAzZ4NzAa8Q==",
       "dev": true,
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.2.0.tgz",
-      "integrity": "sha512-vLzLznK9Y21zQ6F9hf8D6kcIJRb2haAK5T/Vt1uW2CbHYOIfNsR/hJs0XnF/J9ctM20Tfsqv4zBitbYvVw7F6Q==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.4.4.tgz",
+      "integrity": "sha512-EKzz4f49d3/OU0Fplog7nwz/lAfXMaDxtriidyGF9PtR+SRbgv4FhsfF310tKxs6EPj8Y+aWWuX3beN5s+yqGg==",
       "dev": true,
       "dependencies": {
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/types": "^17.4.4",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.2.2"
       },
@@ -872,14 +876,14 @@
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.2.0.tgz",
-      "integrity": "sha512-bbblBhrHkjxra3ptJNm0abxu7yeAaxumQ8ZtD6GIVqzURCETCP7Dm0tlVvGRDyXBuqX6lIJxh3W7oyKqllDsHQ==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.4.4.tgz",
+      "integrity": "sha512-B2TvUMJKK+Svzs6eji23WXsRJ8PAD+orI44lVuVNsm5zmI7O8RSGJMvdEZEikiA4Vohfb+HevaPoWZ7PiFZ3zA==",
       "dev": true,
       "dependencies": {
-        "@commitlint/top-level": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "fs-extra": "^10.0.0",
+        "@commitlint/top-level": "^17.4.0",
+        "@commitlint/types": "^17.4.4",
+        "fs-extra": "^11.0.0",
         "git-raw-commits": "^2.0.0",
         "minimist": "^1.2.6"
       },
@@ -887,16 +891,39 @@
         "node": ">=v14"
       }
     },
-    "node_modules/@commitlint/resolve-extends": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
-      "integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
+    "node_modules/@commitlint/read/node_modules/fs-extra": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dev": true,
       "dependencies": {
-        "@commitlint/config-validator": "^17.1.0",
-        "@commitlint/types": "^17.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@commitlint/read/node_modules/universalify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@commitlint/resolve-extends": {
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.4.4.tgz",
+      "integrity": "sha512-znXr1S0Rr8adInptHw0JeLgumS11lWbk5xAWFVno+HUFVN45875kUtqjrI6AppmD3JI+4s0uZlqqlkepjJd99A==",
+      "dev": true,
+      "dependencies": {
+        "@commitlint/config-validator": "^17.4.4",
+        "@commitlint/types": "^17.4.4",
         "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       },
@@ -905,15 +932,15 @@
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.2.0.tgz",
-      "integrity": "sha512-1YynwD4Eh7HXZNpqG8mtUlL2pSX2jBy61EejYJv4ooZPcg50Ak7LPOyD3a9UZnsE76AXWFBz+yo9Hv4MIpAa0Q==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.4.tgz",
+      "integrity": "sha512-0tgvXnHi/mVcyR8Y8mjTFZIa/FEQXA4uEutXS/imH2v1UNkYDSEMsK/68wiXRpfW1euSgEdwRkvE1z23+yhNrQ==",
       "dev": true,
       "dependencies": {
-        "@commitlint/ensure": "^17.0.0",
-        "@commitlint/message": "^17.2.0",
-        "@commitlint/to-lines": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/ensure": "^17.4.4",
+        "@commitlint/message": "^17.4.2",
+        "@commitlint/to-lines": "^17.4.0",
+        "@commitlint/types": "^17.4.4",
         "execa": "^5.0.0"
       },
       "engines": {
@@ -921,18 +948,18 @@
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.0.0.tgz",
-      "integrity": "sha512-nEi4YEz04Rf2upFbpnEorG8iymyH7o9jYIVFBG1QdzebbIFET3ir+8kQvCZuBE5pKCtViE4XBUsRZz139uFrRQ==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.4.0.tgz",
+      "integrity": "sha512-LcIy/6ZZolsfwDUWfN1mJ+co09soSuNASfKEU5sCmgFCvX5iHwRYLiIuoqXzOVDYOy7E7IcHilr/KS0e5T+0Hg==",
       "dev": true,
       "engines": {
         "node": ">=v14"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.0.0.tgz",
-      "integrity": "sha512-dZrEP1PBJvodNWYPOYiLWf6XZergdksKQaT6i1KSROLdjf5Ai0brLOv5/P+CPxBeoj3vBxK4Ax8H1Pg9t7sHIQ==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.4.0.tgz",
+      "integrity": "sha512-/1loE/g+dTTQgHnjoCy0AexKAEFyHsR2zRB4NWrZ6lZSMIxAhBJnmCqwao7b4H8888PsfoTBCLBYIw8vGnej8g==",
       "dev": true,
       "dependencies": {
         "find-up": "^5.0.0"
@@ -1003,9 +1030,9 @@
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.4.4.tgz",
+      "integrity": "sha512-amRN8tRLYOsxRr6mTnGGGvB5EmW/4DDjLMgiwK3CCVEmN6Sr/6xePGEpWaspKkckILuUORCwe6VfDBw6uj4axQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0"
@@ -1037,15 +1064,15 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.4.0",
-        "globals": "^13.15.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -1082,9 +1109,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -1127,9 +1154,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "dev": true,
       "dependencies": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -1472,9 +1499,9 @@
       }
     },
     "node_modules/@jsii/check-node": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.71.0.tgz",
-      "integrity": "sha512-O4jN/3QhbUdzKVzyiP3P4X5CTPK1+g0+hSTnBSaHpi7F4T1klK+oUF9JBmhFdUtwVJE9bZuySnXkms2f/P0fsw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.75.0.tgz",
+      "integrity": "sha512-ODorfPJwN0920DJrZ/R/G3x0UHgtuhz9y10s6Xox1BDobVXOQpfUl3XEQjrTrSE7kiCt2FxZvazT4xu1MU0y6Q==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.2",
@@ -1500,12 +1527,12 @@
       }
     },
     "node_modules/@jsii/spec": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.71.0.tgz",
-      "integrity": "sha512-qNwCoc1kMTVmjdQ6No8LG3OXAgoySd6CmFGHtRsE1Pc3sd7satYicivhUTtZQsNykf17TCcJLNEQ4aW6/lyF+g==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.75.0.tgz",
+      "integrity": "sha512-aUF5364qgJRCco1C5HBjkDDBGuHZv0uqD5/IXZ2+3A7P/RXdxJdVup0iMGAWKSAx3yPImgyqgD+JxpAnw06YYg==",
       "dev": true,
       "dependencies": {
-        "ajv": "^8.11.0"
+        "ajv": "^8.12.0"
       },
       "engines": {
         "node": ">= 14.6.0"
@@ -1706,14 +1733,14 @@
       }
     },
     "node_modules/@semantic-release/changelog": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.1.tgz",
-      "integrity": "sha512-FT+tAGdWHr0RCM3EpWegWnvXJ05LQtBkQUaQRIExONoXjVjLuOILNm4DEKNaV+GAQyJjbLRVs57ti//GypH6PA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.2.tgz",
+      "integrity": "sha512-jHqfTkoPbDEOAgAP18mGP53IxeMwxTISN+GwTRy9uLu58UjARoZU8ScCgWGeO2WPkEsm57H8AkyY02W2ntIlIw==",
       "dev": true,
       "dependencies": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^11.0.0",
         "lodash": "^4.17.4"
       },
       "engines": {
@@ -1724,18 +1751,17 @@
       }
     },
     "node_modules/@semantic-release/changelog/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+      "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
       "dev": true,
       "dependencies": {
-        "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14.14"
       }
     },
     "node_modules/@semantic-release/changelog/node_modules/universalify": {
@@ -1990,9 +2016,9 @@
       "dev": true
     },
     "node_modules/@types/aws-lambda": {
-      "version": "8.10.108",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.108.tgz",
-      "integrity": "sha512-1yh1W1WoqK3lGHy+V/Fi55zobxrDHUUsluCWdMlOXkCvtsCmHPXOG+CQ2STIL4B1g6xi6I6XzxaF8V9+zeIFLA==",
+      "version": "8.10.110",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.110.tgz",
+      "integrity": "sha512-r6egf2Cwv/JaFTTrF9OXFVUB3j/SXTgM9BwrlbBRjWAa2Tu6GWoDoLflppAZ8uSfbUJdXvC7Br3DjuN9pQ2NUQ==",
       "dev": true
     },
     "node_modules/@types/babel__core": {
@@ -2110,21 +2136,15 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "version": "18.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.19.tgz",
+      "integrity": "sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw==",
       "inBundle": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -2167,15 +2187,16 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
-      "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.52.0.tgz",
+      "integrity": "sha512-lHazYdvYVsBokwCdKOppvYJKaJ4S41CgKBcPvyd0xjZNbvQdhn/pnJlGtQksQ/NhInzdaeaSarlBjDXHuclEbg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/type-utils": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/type-utils": "5.52.0",
+        "@typescript-eslint/utils": "5.52.0",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
@@ -2215,14 +2236,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
-      "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz",
+      "integrity": "sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/typescript-estree": "5.52.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2242,13 +2263,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
-      "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz",
+      "integrity": "sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1"
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2259,13 +2280,13 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
-      "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.52.0.tgz",
+      "integrity": "sha512-tEKuUHfDOv852QGlpPtB3lHOoig5pyFQN/cUiZtpw99D93nEBjexRLre5sQZlkMoHry/lZr8qDAt2oAHLKA6Jw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/typescript-estree": "5.52.0",
+        "@typescript-eslint/utils": "5.52.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       },
@@ -2286,9 +2307,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
-      "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
+      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2299,13 +2320,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
-      "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
+      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1",
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -2341,16 +2362,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
-      "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.52.0.tgz",
+      "integrity": "sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/typescript-estree": "5.52.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -2382,12 +2403,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
-      "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
+      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.42.1",
+        "@typescript-eslint/types": "5.52.0",
         "eslint-visitor-keys": "^3.3.0"
       },
       "engines": {
@@ -2491,9 +2512,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -2627,15 +2648,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/atomic-batcher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
@@ -2655,9 +2667,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.50.0.tgz",
-      "integrity": "sha512-deDbZTI7oyu3rqUyqjwhP6tnUO8MD70lE98yR65xiYty4yXBpsWKbeH3s1wNLpLAWS3hWJYyMtjZ4ZfC35NtVg==",
+      "version": "2.65.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.65.0.tgz",
+      "integrity": "sha512-yTeBe9+Li8ZHZICJc0y1uarbSruc3KIXP1KC7tjVrkg+ye7EE8eJTZm7+PpJd6O0ciPinn/k/dE9gHwUImygGA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -2671,13 +2683,16 @@
       ],
       "dev": true,
       "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.65",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.54",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
+        "punycode": "^2.3.0",
         "semver": "^7.3.8",
         "yaml": "1.10.2"
       },
@@ -2756,7 +2771,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.2.0",
+      "version": "5.2.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2810,7 +2825,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.1.1",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -2858,9 +2873,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1253.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1253.0.tgz",
-      "integrity": "sha512-jlEfWPmRGRdeSVhtRhZnX/vvbJtHu6wzrm7DEUytef5I8P9kxFXnY/lByaXN20WpoU9Kw8zcEOVYIre4LLgswA==",
+      "version": "2.1318.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1318.0.tgz",
+      "integrity": "sha512-xRCKqx4XWXUIpjDCVHmdOSINEVCIC5+yhmgUGR9A6VfxfPs59HbxKyd5LB+CmXhVbwVUM4SRWG5O+agQj+w7Eg==",
       "inBundle": true,
       "dependencies": {
         "buffer": "4.9.2",
@@ -2879,9 +2894,9 @@
       }
     },
     "node_modules/aws-xray-sdk-core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.4.0.tgz",
-      "integrity": "sha512-PH3jqjUp8fTIaRa0i6fjJxXJSR9yDwldH1Qw7nMDNAouL7txsrSM6BhrQEjcaZ2mwfU0PNx8tsFQ+2/nfNdR1w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.4.1.tgz",
+      "integrity": "sha512-HPQ+9GMF+yhDDXNKPp6HGAIv2yVapKTI7WRs2aN3TT+RxQkbmgO+3JlcMvRL2/lu0RqTVWoYCIhmF9/H/zRL1A==",
       "inBundle": true,
       "dependencies": {
         "@aws-sdk/service-error-classification": "^3.4.1",
@@ -3341,9 +3356,9 @@
       }
     },
     "node_modules/codemaker": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.71.0.tgz",
-      "integrity": "sha512-kjpPxr5TRMYr2BG0EP9IEjQAeE6lTT9fybnCBxQdw3ebVoG8pvMshsQmoMwreL7IaloV8EYIkA+cfr/UpQ6CCg==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.75.0.tgz",
+      "integrity": "sha512-HGZQMJb+IXlGD5MJj6Ae2IXzkd4aoIufj/OfM0HxpJnldWx5rlzBjzgpI+YcK1RdaLm3HWMNDtTLti0qMsHtSA==",
       "dev": true,
       "dependencies": {
         "camelcase": "^6.3.0",
@@ -3437,12 +3452,12 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.159",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.159.tgz",
-      "integrity": "sha512-MXr+VXrNnyztGt06Y9reFd+m8vI0S/5/ogtgGQRCiwlz2XUjyTE02FuV4vYxSV8p1B2GY0DN9dubK/7DH5O3PQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.0.tgz",
+      "integrity": "sha512-MIwjmrXZpM9RtwyrSD4HotDIQl8HTdIefQhU+MU1asvtSyVN3kK8kjeUOWMFb+fdyT4RX3QvvcaaPBluLEX1SA==",
       "dev": true,
       "engines": {
-        "node": ">= 14.17.0"
+        "node": ">= 10.17.0"
       }
     },
     "node_modules/conventional-changelog-angular": {
@@ -3541,25 +3556,24 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
+      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
       "dev": true,
       "dependencies": {
-        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "path-type": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/cosmiconfig-typescript-loader": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
-      "integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
+      "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
       "dev": true,
       "engines": {
         "node": ">=12",
@@ -3570,6 +3584,24 @@
         "cosmiconfig": ">=7",
         "ts-node": ">=10",
         "typescript": ">=3"
+      }
+    },
+    "node_modules/cosmiconfig/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/cosmiconfig/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/create-require": {
@@ -3959,17 +3991,126 @@
       "dev": true
     },
     "node_modules/env-ci": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
-      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-8.0.0.tgz",
+      "integrity": "sha512-W+3BqGZozFua9MPeXpmTm5eYEBtGgL76jGu/pwMVp/L8PdECSCEWaIp7d4Mw7kuUrbUldK0oV0bNd6ZZjLiMiA==",
       "dev": true,
       "dependencies": {
-        "execa": "^5.0.0",
-        "fromentries": "^1.3.2",
-        "java-properties": "^1.0.0"
+        "execa": "^6.1.0",
+        "java-properties": "^1.0.2"
       },
       "engines": {
-        "node": ">=10.17"
+        "node": "^16.10 || >=18"
+      }
+    },
+    "node_modules/env-ci/node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/env-ci/node_modules/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/env-ci/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/env-ci/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/error-ex": {
@@ -4022,13 +4163,13 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
-      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
+      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
+        "@eslint/eslintrc": "^1.4.1",
+        "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -4047,7 +4188,7 @@
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.15.0",
+        "globals": "^13.19.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
@@ -4199,9 +4340,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+      "version": "13.20.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+      "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -4532,27 +4673,31 @@
       }
     },
     "node_modules/figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
       "dev": true,
       "dependencies": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/figures/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "dev": true,
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -4593,15 +4738,15 @@
       }
     },
     "node_modules/find-versions": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
-      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
+      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
       "dev": true,
       "dependencies": {
-        "semver-regex": "^3.1.2"
+        "semver-regex": "^4.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4658,26 +4803,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
-    },
-    "node_modules/fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -4995,12 +5120,15 @@
       }
     },
     "node_modules/hook-std": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
-      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
+      "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/hosted-git-info": {
@@ -5070,9 +5198,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
-      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
@@ -5443,6 +5571,18 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isarray": {
       "version": "1.0.0",
@@ -6268,18 +6408,18 @@
       }
     },
     "node_modules/jsii": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.71.0.tgz",
-      "integrity": "sha512-Dn6TvKgMNEsMU/WKliSbVs93Cno238LZZeJTNXk9L6vOR3d7jjEsWh7PJ7NhdyZeft2M3RFJQDKhg8eKeKM/4g==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.75.0.tgz",
+      "integrity": "sha512-9CWt2IQcM6v5k4XZnaSnsK9epfIJfHWMyB69uOjITZpwYjF0CDzLrh/a8l1RyC3COSpp1K1yTjaebHEivyVr4Q==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.71.0",
-        "@jsii/spec": "^1.71.0",
+        "@jsii/check-node": "1.75.0",
+        "@jsii/spec": "^1.75.0",
         "case": "^1.6.3",
         "chalk": "^4",
         "fast-deep-equal": "^3.1.3",
         "fs-extra": "^10.1.0",
-        "log4js": "^6.7.0",
+        "log4js": "^6.7.1",
         "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "sort-json": "^2.0.1",
@@ -6295,20 +6435,20 @@
       }
     },
     "node_modules/jsii-pacmak": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.71.0.tgz",
-      "integrity": "sha512-IaAzJLcvE6fgr7PBjPm/mSb4RCmBT2Ecog8G352J/n15Vqu0vEByvsyK+kxF/ymGAEbODXVN0CV2HjxLQ5FdgA==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.75.0.tgz",
+      "integrity": "sha512-ENH5nNwMjN4CIK9D5mJ8OHDjiwInzQItQQmGwCdPJFLlUN9+9EkhYy2gEPVYPwh7e294c2nJ55DmiOj2CWR17g==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.71.0",
-        "@jsii/spec": "^1.71.0",
+        "@jsii/check-node": "1.75.0",
+        "@jsii/spec": "^1.75.0",
         "clone": "^2.1.2",
-        "codemaker": "^1.71.0",
+        "codemaker": "^1.75.0",
         "commonmark": "^0.30.0",
         "escape-string-regexp": "^4.0.0",
         "fs-extra": "^10.1.0",
-        "jsii-reflect": "^1.71.0",
-        "jsii-rosetta": "^1.71.0",
+        "jsii-reflect": "^1.75.0",
+        "jsii-rosetta": "^1.75.0",
         "semver": "^7.3.8",
         "spdx-license-list": "^6.6.0",
         "xmlbuilder": "^15.1.1",
@@ -6349,16 +6489,16 @@
       }
     },
     "node_modules/jsii-reflect": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.71.0.tgz",
-      "integrity": "sha512-zaufJxtJi7X17bz0ya5Gp6TQ3m4/cbNSxvGboRo4dZGzz1Kaf4qXTlu08sN7NVM6ObTVeyp3atl1KLcf6MKIgw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.75.0.tgz",
+      "integrity": "sha512-oB8X2MpLZbpl8T7XfD+jSADLjzhEMnCZH8BSY3hxSH8TGdhMUZriFHFgmz1NshkZXDh0zRz+xF2a8+uqEIKRYw==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.71.0",
-        "@jsii/spec": "^1.71.0",
+        "@jsii/check-node": "1.75.0",
+        "@jsii/spec": "^1.75.0",
         "chalk": "^4",
         "fs-extra": "^10.1.0",
-        "oo-ascii-tree": "^1.71.0",
+        "oo-ascii-tree": "^1.75.0",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -6369,9 +6509,9 @@
       }
     },
     "node_modules/jsii-release": {
-      "version": "0.2.521",
-      "resolved": "https://registry.npmjs.org/jsii-release/-/jsii-release-0.2.521.tgz",
-      "integrity": "sha512-OxAtMHTOmcVW2t5orlDeGsHT1iT4aFCqeu06DxMXPiAC4WZxOZ8JehIxsYDRZyMyyXBY3vd5AJTBgmElEoToPA==",
+      "version": "0.2.598",
+      "resolved": "https://registry.npmjs.org/jsii-release/-/jsii-release-0.2.598.tgz",
+      "integrity": "sha512-2dPz76WV8eNFU+OrMKeu/inbADI9DEeOeVeBpbKQDC150TA0nZ+z/04jcRuI/tbXoqm1fghCI3EgLL0bRgl4yA==",
       "dev": true,
       "dependencies": {
         "@types/fs-extra": "^8.0.0",
@@ -6427,21 +6567,21 @@
       }
     },
     "node_modules/jsii-rosetta": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.71.0.tgz",
-      "integrity": "sha512-Iu36Dxpu1JphYnicmnPvS4AsqmeOwExjenVqmGJaIJwdMG6W9ou3WM1FoUa7LzenaJiFY9jj1CvbD05xgAo+ow==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.75.0.tgz",
+      "integrity": "sha512-zsV8F0BoXTvS46N1/QCwapMXamQhJKFaAIapFBWk0a4l84v+FSYOWnKbgZz+FVZEuu3VBJpxg6uKE9R9A8Hvag==",
       "dev": true,
       "dependencies": {
-        "@jsii/check-node": "1.71.0",
-        "@jsii/spec": "1.71.0",
-        "@xmldom/xmldom": "^0.8.5",
+        "@jsii/check-node": "1.75.0",
+        "@jsii/spec": "1.75.0",
+        "@xmldom/xmldom": "^0.8.6",
         "commonmark": "^0.30.0",
         "fast-glob": "^3.2.12",
-        "jsii": "1.71.0",
+        "jsii": "1.75.0",
         "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "typescript": "~3.9.10",
-        "workerpool": "^6.3.0",
+        "workerpool": "^6.3.1",
         "yargs": "^16.2.0"
       },
       "bin": {
@@ -6466,6 +6606,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/jsii-rosetta/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/jsii/node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -6479,6 +6632,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/jsii/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/json-parse-better-errors": {
@@ -6679,6 +6845,18 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -6689,6 +6867,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true
+    },
+    "node_modules/lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
       "dev": true
     },
     "node_modules/lodash.ismatch": {
@@ -6709,6 +6893,12 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true
     },
+    "node_modules/lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -6721,16 +6911,46 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true
+    },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true
     },
+    "node_modules/lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+      "dev": true
+    },
     "node_modules/log4js": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.0.tgz",
-      "integrity": "sha512-KA0W9ffgNBLDj6fZCq/lRbgR6ABAodRIDHrZnS48vOtfKa4PzWImb0Md1lmGCdO3n3sbCm/n1/WmrNlZ8kCI3Q==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.1.tgz",
+      "integrity": "sha512-lzbd0Eq1HRdWM2abSD7mk6YIVY0AogGJzb/z+lqzRk+8+XJP+M6L1MS5FUSc3jjGru4dbKjEMJmqlsoYYpuivQ==",
       "dev": true,
       "dependencies": {
         "date-format": "^4.0.14",
@@ -9819,9 +10039,9 @@
       }
     },
     "node_modules/oo-ascii-tree": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.71.0.tgz",
-      "integrity": "sha512-20AV6WE6Z9wUsmTmunnmSt7hDQCXWquYEtlkeITdHs4eGiZ/vgsf5E1TPyVLBpA6Nm0Dy9CXY87r83uotZLzbw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.75.0.tgz",
+      "integrity": "sha512-rM9YrFT0Zzes3nLF37sGJIlHIjLQpnEI17LcbioXw83oMHqdc8QW5pE9/IHkYlYRbN2Z+sRouSCkrXFZRai2Mg==",
       "dev": true,
       "engines": {
         "node": ">= 14.6.0"
@@ -9845,12 +10065,12 @@
       }
     },
     "node_modules/p-each-series": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
-      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+      "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10625,9 +10845,9 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
-      "integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-20.1.0.tgz",
+      "integrity": "sha512-+9+n6RIr0Fz0F53cXrjpawxWlUg3O7/qr1jF9lrE+/v6WqwBrSWnavVHTPaf2WLerET2EngoqI0M4pahkKl6XQ==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^9.0.2",
@@ -10635,35 +10855,340 @@
         "@semantic-release/github": "^8.0.0",
         "@semantic-release/npm": "^9.0.0",
         "@semantic-release/release-notes-generator": "^10.0.0",
-        "aggregate-error": "^3.0.0",
-        "cosmiconfig": "^7.0.0",
+        "aggregate-error": "^4.0.1",
+        "cosmiconfig": "^8.0.0",
         "debug": "^4.0.0",
-        "env-ci": "^5.0.0",
-        "execa": "^5.0.0",
-        "figures": "^3.0.0",
-        "find-versions": "^4.0.0",
+        "env-ci": "^8.0.0",
+        "execa": "^6.1.0",
+        "figures": "^5.0.0",
+        "find-versions": "^5.1.0",
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
-        "hook-std": "^2.0.0",
-        "hosted-git-info": "^4.0.0",
-        "lodash": "^4.17.21",
-        "marked": "^4.0.10",
-        "marked-terminal": "^5.0.0",
+        "hook-std": "^3.0.0",
+        "hosted-git-info": "^6.0.0",
+        "lodash-es": "^4.17.21",
+        "marked": "^4.1.0",
+        "marked-terminal": "^5.1.1",
         "micromatch": "^4.0.2",
-        "p-each-series": "^2.1.0",
-        "p-reduce": "^2.0.0",
-        "read-pkg-up": "^7.0.0",
+        "p-each-series": "^3.0.0",
+        "p-reduce": "^3.0.0",
+        "read-pkg-up": "^9.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
-        "semver-diff": "^3.1.1",
+        "semver-diff": "^4.0.0",
         "signale": "^1.2.1",
-        "yargs": "^16.2.0"
+        "yargs": "^17.5.1"
       },
       "bin": {
         "semantic-release": "bin/semantic-release.js"
       },
       "engines": {
-        "node": ">=16 || ^14.17"
+        "node": ">=18"
+      }
+    },
+    "node_modules/semantic-release/node_modules/aggregate-error": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^4.0.0",
+        "indent-string": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/clean-stack": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/semantic-release/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/execa": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+      "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.1",
+        "human-signals": "^3.0.1",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^3.0.7",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/semantic-release/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/hosted-git-info": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+      "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^7.5.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.16.1.tgz",
+      "integrity": "sha512-9kkuMZHnLH/8qXARvYSjNvq8S1GYFFzynQTAfKeaJ0sIrR3PUPuu37Z+EiIANiZBvpfTf2B5y8ecDLSMWlLv+w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/semantic-release/node_modules/human-signals": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+      "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/p-reduce": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+      "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/semantic-release/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/read-pkg": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
+      "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.1",
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/read-pkg-up": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
+      "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^6.3.0",
+        "read-pkg": "^7.1.0",
+        "type-fest": "^2.5.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semantic-release/node_modules/semver": {
@@ -10681,6 +11206,69 @@
         "node": ">=10"
       }
     },
+    "node_modules/semantic-release/node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yargs": {
+      "version": "17.7.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.0.tgz",
+      "integrity": "sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/semantic-release/node_modules/yocto-queue": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -10691,15 +11279,33 @@
       }
     },
     "node_modules/semver-diff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
+      "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
       "dev": true,
       "dependencies": {
-        "semver": "^6.3.0"
+        "semver": "^7.3.5"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/semver-diff/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/semver-intersect": {
@@ -10721,12 +11327,12 @@
       }
     },
     "node_modules/semver-regex": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
-      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11045,9 +11651,9 @@
       }
     },
     "node_modules/streamroller": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.3.tgz",
-      "integrity": "sha512-CphIJyFx2SALGHeINanjFRKQ4l7x2c+rXYJ4BMq0gd+ZK0gi4VT8b+eHe2wi58x4UayBAKx4xtHpXT/ea1cz8w==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
       "dev": true,
       "dependencies": {
         "date-format": "^4.0.14",
@@ -11595,9 +12201,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -12026,15 +12632,6 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -12094,6 +12691,24 @@
         "@jridgewell/gen-mapping": "^0.1.0",
         "@jridgewell/trace-mapping": "^0.3.9"
       }
+    },
+    "@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.72",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.72.tgz",
+      "integrity": "sha512-7Qo7fkvodB8TUncfYPH+XLVFybt7AWKzLg7HWLT/GBrv9mZ3Iwf9Zq1YNoVqHEaNnqd9rnTrWjoAoDIOB0pZeg==",
+      "dev": true
+    },
+    "@aws-cdk/asset-kubectl-v20": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.1.tgz",
+      "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw==",
+      "dev": true
+    },
+    "@aws-cdk/asset-node-proxy-agent-v5": {
+      "version": "2.0.61",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.61.tgz",
+      "integrity": "sha512-SZZk/NtuAGHnPZV1egzrBu90zNrwvERfAOB1P6WxLkK8vbbi7pyumBpUXQ5Gxz4WhYHrmixSO/i7eBUZ2FAM8Q==",
+      "dev": true
     },
     "@aws-sdk/service-error-classification": {
       "version": "3.208.0",
@@ -12528,18 +13143,18 @@
       "optional": true
     },
     "@commitlint/cli": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.2.0.tgz",
-      "integrity": "sha512-kd1zykcrjIKyDRftWW1E1TJqkgzeosEkv1BiYPCdzkb/g/3BrfgwZUHR1vg+HO3qKUb/0dN+jNXArhGGAHpmaQ==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-17.4.4.tgz",
+      "integrity": "sha512-HwKlD7CPVMVGTAeFZylVNy14Vm5POVY0WxPkZr7EXLC/os0LH/obs6z4HRvJtH/nHCMYBvUBQhGwnufKfTjd5g==",
       "dev": true,
       "requires": {
-        "@commitlint/format": "^17.0.0",
-        "@commitlint/lint": "^17.2.0",
-        "@commitlint/load": "^17.2.0",
-        "@commitlint/read": "^17.2.0",
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/format": "^17.4.4",
+        "@commitlint/lint": "^17.4.4",
+        "@commitlint/load": "^17.4.4",
+        "@commitlint/read": "^17.4.4",
+        "@commitlint/types": "^17.4.4",
         "execa": "^5.0.0",
-        "lodash": "^4.17.19",
+        "lodash.isfunction": "^3.0.9",
         "resolve-from": "5.0.0",
         "resolve-global": "1.0.0",
         "yargs": "^17.0.0"
@@ -12580,64 +13195,68 @@
       }
     },
     "@commitlint/config-conventional": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.2.0.tgz",
-      "integrity": "sha512-g5hQqRa80f++SYS233dbDSg16YdyounMTAhVcmqtInNeY/GF3aA4st9SVtJxpeGrGmueMrU4L+BBb+6Vs5wrcg==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-17.4.4.tgz",
+      "integrity": "sha512-u6ztvxqzi6NuhrcEDR7a+z0yrh11elY66nRrQIpqsqW6sZmpxYkDLtpRH8jRML+mmxYQ8s4qqF06Q/IQx5aJeQ==",
       "dev": true,
       "requires": {
         "conventional-changelog-conventionalcommits": "^5.0.0"
       }
     },
     "@commitlint/config-validator": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.1.0.tgz",
-      "integrity": "sha512-Q1rRRSU09ngrTgeTXHq6ePJs2KrI+axPTgkNYDWSJIuS1Op4w3J30vUfSXjwn5YEJHklK3fSqWNHmBhmTR7Vdg==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-17.4.4.tgz",
+      "integrity": "sha512-bi0+TstqMiqoBAQDvdEP4AFh0GaKyLFlPPEObgI29utoKEYoPQTvF0EYqIwYYLEoJYhj5GfMIhPHJkTJhagfeg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/types": "^17.4.4",
         "ajv": "^8.11.0"
       }
     },
     "@commitlint/ensure": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.0.0.tgz",
-      "integrity": "sha512-M2hkJnNXvEni59S0QPOnqCKIK52G1XyXBGw51mvh7OXDudCmZ9tZiIPpU882p475Mhx48Ien1MbWjCP1zlyC0A==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-17.4.4.tgz",
+      "integrity": "sha512-AHsFCNh8hbhJiuZ2qHv/m59W/GRE9UeOXbkOqxYMNNg9pJ7qELnFcwj5oYpa6vzTSHtPGKf3C2yUFNy1GGHq6g==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^17.0.0",
-        "lodash": "^4.17.19"
+        "@commitlint/types": "^17.4.4",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.kebabcase": "^4.1.1",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.startcase": "^4.4.0",
+        "lodash.upperfirst": "^4.3.1"
       }
     },
     "@commitlint/execute-rule": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.0.0.tgz",
-      "integrity": "sha512-nVjL/w/zuqjCqSJm8UfpNaw66V9WzuJtQvEnCrK4jDw6qKTmZB+1JQ8m6BQVZbNBcwfYdDNKnhIhqI0Rk7lgpQ==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-17.4.0.tgz",
+      "integrity": "sha512-LIgYXuCSO5Gvtc0t9bebAMSwd68ewzmqLypqI2Kke1rqOqqDbMpYcYfoPfFlv9eyLIh4jocHWwCK5FS7z9icUA==",
       "dev": true
     },
     "@commitlint/format": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.0.0.tgz",
-      "integrity": "sha512-MZzJv7rBp/r6ZQJDEodoZvdRM0vXu1PfQvMTNWFb8jFraxnISMTnPBWMMjr2G/puoMashwaNM//fl7j8gGV5lA==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-17.4.4.tgz",
+      "integrity": "sha512-+IS7vpC4Gd/x+uyQPTAt3hXs5NxnkqAZ3aqrHd5Bx/R9skyCAWusNlNbw3InDbAK6j166D9asQM8fnmYIa+CXQ==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/types": "^17.4.4",
         "chalk": "^4.1.0"
       }
     },
     "@commitlint/is-ignored": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.2.0.tgz",
-      "integrity": "sha512-rgUPUQraHxoMLxiE8GK430HA7/R2vXyLcOT4fQooNrZq9ERutNrP6dw3gdKLkq22Nede3+gEHQYUzL4Wu75ndg==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-17.4.4.tgz",
+      "integrity": "sha512-Y3eo1SFJ2JQDik4rWkBC4tlRIxlXEFrRWxcyrzb1PUT2k3kZ/XGNuCDfk/u0bU2/yS0tOA/mTjFsV+C4qyACHw==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^17.0.0",
-        "semver": "7.3.7"
+        "@commitlint/types": "^17.4.4",
+        "semver": "7.3.8"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -12646,118 +13265,125 @@
       }
     },
     "@commitlint/lint": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.2.0.tgz",
-      "integrity": "sha512-N2oLn4Dj672wKH5qJ4LGO+73UkYXGHO+NTVUusGw83SjEv7GjpqPGKU6KALW2kFQ/GsDefSvOjpSi3CzWHQBDg==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-17.4.4.tgz",
+      "integrity": "sha512-qgkCRRFjyhbMDWsti/5jRYVJkgYZj4r+ZmweZObnbYqPUl5UKLWMf9a/ZZisOI4JfiPmRktYRZ2JmqlSvg+ccw==",
       "dev": true,
       "requires": {
-        "@commitlint/is-ignored": "^17.2.0",
-        "@commitlint/parse": "^17.2.0",
-        "@commitlint/rules": "^17.2.0",
-        "@commitlint/types": "^17.0.0"
+        "@commitlint/is-ignored": "^17.4.4",
+        "@commitlint/parse": "^17.4.4",
+        "@commitlint/rules": "^17.4.4",
+        "@commitlint/types": "^17.4.4"
       }
     },
     "@commitlint/load": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.2.0.tgz",
-      "integrity": "sha512-HDD57qSqNrk399R4TIjw31AWBG8dBjNj1MrDKZKmC/wvimtnIFlqzcu1+sxfXIOHj/+M6tcMWDtvknGUd7SU+g==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-17.4.4.tgz",
+      "integrity": "sha512-z6uFIQ7wfKX5FGBe1AkOF4l/ShOQsaa1ml/nLMkbW7R/xF8galGS7Zh0yHvzVp/srtfS0brC+0bUfQfmpMPFVQ==",
       "dev": true,
       "requires": {
-        "@commitlint/config-validator": "^17.1.0",
-        "@commitlint/execute-rule": "^17.0.0",
-        "@commitlint/resolve-extends": "^17.1.0",
-        "@commitlint/types": "^17.0.0",
-        "@types/node": "^14.0.0",
+        "@commitlint/config-validator": "^17.4.4",
+        "@commitlint/execute-rule": "^17.4.0",
+        "@commitlint/resolve-extends": "^17.4.4",
+        "@commitlint/types": "^17.4.4",
+        "@types/node": "*",
         "chalk": "^4.1.0",
-        "cosmiconfig": "^7.0.0",
+        "cosmiconfig": "^8.0.0",
         "cosmiconfig-typescript-loader": "^4.0.0",
-        "lodash": "^4.17.19",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "lodash.uniq": "^4.5.0",
         "resolve-from": "^5.0.0",
         "ts-node": "^10.8.1",
         "typescript": "^4.6.4"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "14.18.33",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.33.tgz",
-          "integrity": "sha512-qelS/Ra6sacc4loe/3MSjXNL1dNQ/GjxNHVzuChwMfmk7HuycRLVQN2qNY3XahK+fZc5E2szqQSKUyAF0E+2bg==",
-          "dev": true
-        },
-        "typescript": {
-          "version": "4.8.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-          "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-          "dev": true
-        }
       }
     },
     "@commitlint/message": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.2.0.tgz",
-      "integrity": "sha512-/4l2KFKxBOuoEn1YAuuNNlAU05Zt7sNsC9H0mPdPm3chOrT4rcX0pOqrQcLtdMrMkJz0gC7b3SF80q2+LtdL9Q==",
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-17.4.2.tgz",
+      "integrity": "sha512-3XMNbzB+3bhKA1hSAWPCQA3lNxR4zaeQAQcHj0Hx5sVdO6ryXtgUBGGv+1ZCLMgAPRixuc6en+iNAzZ4NzAa8Q==",
       "dev": true
     },
     "@commitlint/parse": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.2.0.tgz",
-      "integrity": "sha512-vLzLznK9Y21zQ6F9hf8D6kcIJRb2haAK5T/Vt1uW2CbHYOIfNsR/hJs0XnF/J9ctM20Tfsqv4zBitbYvVw7F6Q==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-17.4.4.tgz",
+      "integrity": "sha512-EKzz4f49d3/OU0Fplog7nwz/lAfXMaDxtriidyGF9PtR+SRbgv4FhsfF310tKxs6EPj8Y+aWWuX3beN5s+yqGg==",
       "dev": true,
       "requires": {
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/types": "^17.4.4",
         "conventional-changelog-angular": "^5.0.11",
         "conventional-commits-parser": "^3.2.2"
       }
     },
     "@commitlint/read": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.2.0.tgz",
-      "integrity": "sha512-bbblBhrHkjxra3ptJNm0abxu7yeAaxumQ8ZtD6GIVqzURCETCP7Dm0tlVvGRDyXBuqX6lIJxh3W7oyKqllDsHQ==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-17.4.4.tgz",
+      "integrity": "sha512-B2TvUMJKK+Svzs6eji23WXsRJ8PAD+orI44lVuVNsm5zmI7O8RSGJMvdEZEikiA4Vohfb+HevaPoWZ7PiFZ3zA==",
       "dev": true,
       "requires": {
-        "@commitlint/top-level": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
-        "fs-extra": "^10.0.0",
+        "@commitlint/top-level": "^17.4.0",
+        "@commitlint/types": "^17.4.4",
+        "fs-extra": "^11.0.0",
         "git-raw-commits": "^2.0.0",
         "minimist": "^1.2.6"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
+        }
       }
     },
     "@commitlint/resolve-extends": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.1.0.tgz",
-      "integrity": "sha512-jqKm00LJ59T0O8O4bH4oMa4XyJVEOK4GzH8Qye9XKji+Q1FxhZznxMV/bDLyYkzbTodBt9sL0WLql8wMtRTbqQ==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-17.4.4.tgz",
+      "integrity": "sha512-znXr1S0Rr8adInptHw0JeLgumS11lWbk5xAWFVno+HUFVN45875kUtqjrI6AppmD3JI+4s0uZlqqlkepjJd99A==",
       "dev": true,
       "requires": {
-        "@commitlint/config-validator": "^17.1.0",
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/config-validator": "^17.4.4",
+        "@commitlint/types": "^17.4.4",
         "import-fresh": "^3.0.0",
-        "lodash": "^4.17.19",
+        "lodash.mergewith": "^4.6.2",
         "resolve-from": "^5.0.0",
         "resolve-global": "^1.0.0"
       }
     },
     "@commitlint/rules": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.2.0.tgz",
-      "integrity": "sha512-1YynwD4Eh7HXZNpqG8mtUlL2pSX2jBy61EejYJv4ooZPcg50Ak7LPOyD3a9UZnsE76AXWFBz+yo9Hv4MIpAa0Q==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-17.4.4.tgz",
+      "integrity": "sha512-0tgvXnHi/mVcyR8Y8mjTFZIa/FEQXA4uEutXS/imH2v1UNkYDSEMsK/68wiXRpfW1euSgEdwRkvE1z23+yhNrQ==",
       "dev": true,
       "requires": {
-        "@commitlint/ensure": "^17.0.0",
-        "@commitlint/message": "^17.2.0",
-        "@commitlint/to-lines": "^17.0.0",
-        "@commitlint/types": "^17.0.0",
+        "@commitlint/ensure": "^17.4.4",
+        "@commitlint/message": "^17.4.2",
+        "@commitlint/to-lines": "^17.4.0",
+        "@commitlint/types": "^17.4.4",
         "execa": "^5.0.0"
       }
     },
     "@commitlint/to-lines": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.0.0.tgz",
-      "integrity": "sha512-nEi4YEz04Rf2upFbpnEorG8iymyH7o9jYIVFBG1QdzebbIFET3ir+8kQvCZuBE5pKCtViE4XBUsRZz139uFrRQ==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-17.4.0.tgz",
+      "integrity": "sha512-LcIy/6ZZolsfwDUWfN1mJ+co09soSuNASfKEU5sCmgFCvX5iHwRYLiIuoqXzOVDYOy7E7IcHilr/KS0e5T+0Hg==",
       "dev": true
     },
     "@commitlint/top-level": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.0.0.tgz",
-      "integrity": "sha512-dZrEP1PBJvodNWYPOYiLWf6XZergdksKQaT6i1KSROLdjf5Ai0brLOv5/P+CPxBeoj3vBxK4Ax8H1Pg9t7sHIQ==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-17.4.0.tgz",
+      "integrity": "sha512-/1loE/g+dTTQgHnjoCy0AexKAEFyHsR2zRB4NWrZ6lZSMIxAhBJnmCqwao7b4H8888PsfoTBCLBYIw8vGnej8g==",
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
@@ -12803,9 +13429,9 @@
       }
     },
     "@commitlint/types": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.0.0.tgz",
-      "integrity": "sha512-hBAw6U+SkAT5h47zDMeOu3HSiD0SODw4Aq7rRNh1ceUmL7GyLKYhPbUvlRWqZ65XjBLPHZhFyQlRaPNz8qvUyQ==",
+      "version": "17.4.4",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-17.4.4.tgz",
+      "integrity": "sha512-amRN8tRLYOsxRr6mTnGGGvB5EmW/4DDjLMgiwK3CCVEmN6Sr/6xePGEpWaspKkckILuUORCwe6VfDBw6uj4axQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0"
@@ -12833,15 +13459,15 @@
       }
     },
     "@eslint/eslintrc": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
-      "integrity": "sha512-uj3pT6Mg+3t39fvLrj8iuCIJ38zKO9FpGtJ4BBJebJhEwjoT+KLVNCcHT5QC9NGRIEi7fZ0ZR8YRb884auB4Lg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
         "espree": "^9.4.0",
-        "globals": "^13.15.0",
+        "globals": "^13.19.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -12868,9 +13494,9 @@
           "dev": true
         },
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.20.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+          "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -12900,9 +13526,9 @@
       }
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.7.tgz",
-      "integrity": "sha512-kBbPWzN8oVMLb0hOUYXhmxggL/1cJE6ydvjDIGi9EnAGUyA7cLVKQg+d/Dsm+KZwx2czGHrCmMVLiyg8s5JPKw==",
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
+      "integrity": "sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==",
       "dev": true,
       "requires": {
         "@humanwhocodes/object-schema": "^1.2.1",
@@ -13171,9 +13797,9 @@
       }
     },
     "@jsii/check-node": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.71.0.tgz",
-      "integrity": "sha512-O4jN/3QhbUdzKVzyiP3P4X5CTPK1+g0+hSTnBSaHpi7F4T1klK+oUF9JBmhFdUtwVJE9bZuySnXkms2f/P0fsw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@jsii/check-node/-/check-node-1.75.0.tgz",
+      "integrity": "sha512-ODorfPJwN0920DJrZ/R/G3x0UHgtuhz9y10s6Xox1BDobVXOQpfUl3XEQjrTrSE7kiCt2FxZvazT4xu1MU0y6Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.2",
@@ -13192,12 +13818,12 @@
       }
     },
     "@jsii/spec": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.71.0.tgz",
-      "integrity": "sha512-qNwCoc1kMTVmjdQ6No8LG3OXAgoySd6CmFGHtRsE1Pc3sd7satYicivhUTtZQsNykf17TCcJLNEQ4aW6/lyF+g==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/@jsii/spec/-/spec-1.75.0.tgz",
+      "integrity": "sha512-aUF5364qgJRCco1C5HBjkDDBGuHZv0uqD5/IXZ2+3A7P/RXdxJdVup0iMGAWKSAx3yPImgyqgD+JxpAnw06YYg==",
       "dev": true,
       "requires": {
-        "ajv": "^8.11.0"
+        "ajv": "^8.12.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -13351,24 +13977,23 @@
       }
     },
     "@semantic-release/changelog": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.1.tgz",
-      "integrity": "sha512-FT+tAGdWHr0RCM3EpWegWnvXJ05LQtBkQUaQRIExONoXjVjLuOILNm4DEKNaV+GAQyJjbLRVs57ti//GypH6PA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-6.0.2.tgz",
+      "integrity": "sha512-jHqfTkoPbDEOAgAP18mGP53IxeMwxTISN+GwTRy9uLu58UjARoZU8ScCgWGeO2WPkEsm57H8AkyY02W2ntIlIw==",
       "dev": true,
       "requires": {
         "@semantic-release/error": "^3.0.0",
         "aggregate-error": "^3.0.0",
-        "fs-extra": "^9.0.0",
+        "fs-extra": "^11.0.0",
         "lodash": "^4.17.4"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.1.0.tgz",
+          "integrity": "sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==",
           "dev": true,
           "requires": {
-            "at-least-node": "^1.0.0",
             "graceful-fs": "^4.2.0",
             "jsonfile": "^6.0.1",
             "universalify": "^2.0.0"
@@ -13575,9 +14200,9 @@
       "dev": true
     },
     "@types/aws-lambda": {
-      "version": "8.10.108",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.108.tgz",
-      "integrity": "sha512-1yh1W1WoqK3lGHy+V/Fi55zobxrDHUUsluCWdMlOXkCvtsCmHPXOG+CQ2STIL4B1g6xi6I6XzxaF8V9+zeIFLA==",
+      "version": "8.10.110",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.110.tgz",
+      "integrity": "sha512-r6egf2Cwv/JaFTTrF9OXFVUB3j/SXTgM9BwrlbBRjWAa2Tu6GWoDoLflppAZ8uSfbUJdXvC7Br3DjuN9pQ2NUQ==",
       "dev": true
     },
     "@types/babel__core": {
@@ -13694,20 +14319,14 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
-      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg=="
+      "version": "18.11.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.19.tgz",
+      "integrity": "sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
       "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
-      "dev": true
-    },
-    "@types/parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/prettier": {
@@ -13750,15 +14369,16 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.42.1.tgz",
-      "integrity": "sha512-LyR6x784JCiJ1j6sH5Y0K6cdExqCCm8DJUTcwG5ThNXJj/G8o5E56u5EdG4SLy+bZAwZBswC+GYn3eGdttBVCg==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.52.0.tgz",
+      "integrity": "sha512-lHazYdvYVsBokwCdKOppvYJKaJ4S41CgKBcPvyd0xjZNbvQdhn/pnJlGtQksQ/NhInzdaeaSarlBjDXHuclEbg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/type-utils": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/type-utils": "5.52.0",
+        "@typescript-eslint/utils": "5.52.0",
         "debug": "^4.3.4",
+        "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "natural-compare-lite": "^1.4.0",
         "regexpp": "^3.2.0",
@@ -13778,53 +14398,53 @@
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.42.1.tgz",
-      "integrity": "sha512-kAV+NiNBWVQDY9gDJDToTE/NO8BHi4f6b7zTsVAJoTkmB/zlfOpiEVBzHOKtlgTndCKe8vj9F/PuolemZSh50Q==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.52.0.tgz",
+      "integrity": "sha512-e2KiLQOZRo4Y0D/b+3y08i3jsekoSkOYStROYmPUnGMEoA0h+k2qOH5H6tcjIc68WDvGwH+PaOrP1XRzLJ6QlA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/typescript-estree": "5.52.0",
         "debug": "^4.3.4"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.42.1.tgz",
-      "integrity": "sha512-QAZY/CBP1Emx4rzxurgqj3rUinfsh/6mvuKbLNMfJMMKYLRBfweus8brgXF8f64ABkIZ3zdj2/rYYtF8eiuksQ==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.52.0.tgz",
+      "integrity": "sha512-AR7sxxfBKiNV0FWBSARxM8DmNxrwgnYMPwmpkC1Pl1n+eT8/I2NAUPuwDy/FmDcC6F8pBfmOcaxcxRHspgOBMw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1"
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.42.1.tgz",
-      "integrity": "sha512-WWiMChneex5w4xPIX56SSnQQo0tEOy5ZV2dqmj8Z371LJ0E+aymWD25JQ/l4FOuuX+Q49A7pzh/CGIQflxMVXg==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.52.0.tgz",
+      "integrity": "sha512-tEKuUHfDOv852QGlpPtB3lHOoig5pyFQN/cUiZtpw99D93nEBjexRLre5sQZlkMoHry/lZr8qDAt2oAHLKA6Jw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/typescript-estree": "5.42.1",
-        "@typescript-eslint/utils": "5.42.1",
+        "@typescript-eslint/typescript-estree": "5.52.0",
+        "@typescript-eslint/utils": "5.52.0",
         "debug": "^4.3.4",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.42.1.tgz",
-      "integrity": "sha512-Qrco9dsFF5lhalz+lLFtxs3ui1/YfC6NdXu+RAGBa8uSfn01cjO7ssCsjIsUs484vny9Xm699FSKwpkCcqwWwA==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.52.0.tgz",
+      "integrity": "sha512-oV7XU4CHYfBhk78fS7tkum+/Dpgsfi91IIDy7fjCyq2k6KB63M6gMC0YIvy+iABzmXThCRI6xpCEyVObBdWSDQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.42.1.tgz",
-      "integrity": "sha512-qElc0bDOuO0B8wDhhW4mYVgi/LZL+igPwXtV87n69/kYC/7NG3MES0jHxJNCr4EP7kY1XVsRy8C/u3DYeTKQmw==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.52.0.tgz",
+      "integrity": "sha512-WeWnjanyEwt6+fVrSR0MYgEpUAuROxuAH516WPjUblIrClzYJj0kBbjdnbQXLpgAN8qbEuGywiQsXUVDiAoEuQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/visitor-keys": "5.42.1",
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/visitor-keys": "5.52.0",
         "debug": "^4.3.4",
         "globby": "^11.1.0",
         "is-glob": "^4.0.3",
@@ -13844,16 +14464,16 @@
       }
     },
     "@typescript-eslint/utils": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.42.1.tgz",
-      "integrity": "sha512-Gxvf12xSp3iYZd/fLqiQRD4uKZjDNR01bQ+j8zvhPjpsZ4HmvEFL/tC4amGNyxN9Rq+iqvpHLhlqx6KTxz9ZyQ==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.52.0.tgz",
+      "integrity": "sha512-As3lChhrbwWQLNk2HC8Ree96hldKIqk98EYvypd3It8Q1f8d5zWyIoaZEp2va5667M4ZyE7X8UUR+azXrFl+NA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
         "@types/semver": "^7.3.12",
-        "@typescript-eslint/scope-manager": "5.42.1",
-        "@typescript-eslint/types": "5.42.1",
-        "@typescript-eslint/typescript-estree": "5.42.1",
+        "@typescript-eslint/scope-manager": "5.52.0",
+        "@typescript-eslint/types": "5.52.0",
+        "@typescript-eslint/typescript-estree": "5.52.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0",
         "semver": "^7.3.7"
@@ -13871,12 +14491,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.42.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.42.1.tgz",
-      "integrity": "sha512-LOQtSF4z+hejmpUvitPlc4hA7ERGoj2BVkesOcG91HCn8edLGUXbTrErmutmPbl8Bo9HjAvOO/zBKQHExXNA2A==",
+      "version": "5.52.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.52.0.tgz",
+      "integrity": "sha512-qMwpw6SU5VHCPr99y274xhbm+PRViK/NATY6qzt+Et7+mThGuFSl/ompj2/hrBlRP/kq+BFdgagnOSgw9TB0eA==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.42.1",
+        "@typescript-eslint/types": "5.52.0",
         "eslint-visitor-keys": "^3.3.0"
       }
     },
@@ -13949,9 +14569,9 @@
       }
     },
     "ajv": {
-      "version": "8.11.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.2.tgz",
-      "integrity": "sha512-E4bfmKAhGiSTvMfL1Myyycaub+cUEU2/IvpylXkUu7CHBkBj1f/ikdzbD7YQ6FKUbixDxeYvB/xY4fvyroDlQg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -14053,12 +14673,6 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
-    },
     "atomic-batcher": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/atomic-batcher/-/atomic-batcher-1.0.2.tgz",
@@ -14070,18 +14684,21 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-cdk-lib": {
-      "version": "2.50.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.50.0.tgz",
-      "integrity": "sha512-deDbZTI7oyu3rqUyqjwhP6tnUO8MD70lE98yR65xiYty4yXBpsWKbeH3s1wNLpLAWS3hWJYyMtjZ4ZfC35NtVg==",
+      "version": "2.65.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.65.0.tgz",
+      "integrity": "sha512-yTeBe9+Li8ZHZICJc0y1uarbSruc3KIXP1KC7tjVrkg+ye7EE8eJTZm7+PpJd6O0ciPinn/k/dE9gHwUImygGA==",
       "dev": true,
       "requires": {
+        "@aws-cdk/asset-awscli-v1": "^2.2.65",
+        "@aws-cdk/asset-kubectl-v20": "^2.1.1",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.54",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
-        "ignore": "^5.2.0",
+        "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.1.1",
+        "punycode": "^2.3.0",
         "semver": "^7.3.8",
         "yaml": "1.10.2"
       },
@@ -14137,7 +14754,7 @@
           "dev": true
         },
         "ignore": {
-          "version": "5.2.0",
+          "version": "5.2.4",
           "bundled": true,
           "dev": true
         },
@@ -14172,7 +14789,7 @@
           }
         },
         "punycode": {
-          "version": "2.1.1",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true
         },
@@ -14202,9 +14819,9 @@
       }
     },
     "aws-sdk": {
-      "version": "2.1253.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1253.0.tgz",
-      "integrity": "sha512-jlEfWPmRGRdeSVhtRhZnX/vvbJtHu6wzrm7DEUytef5I8P9kxFXnY/lByaXN20WpoU9Kw8zcEOVYIre4LLgswA==",
+      "version": "2.1318.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1318.0.tgz",
+      "integrity": "sha512-xRCKqx4XWXUIpjDCVHmdOSINEVCIC5+yhmgUGR9A6VfxfPs59HbxKyd5LB+CmXhVbwVUM4SRWG5O+agQj+w7Eg==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -14219,9 +14836,9 @@
       }
     },
     "aws-xray-sdk-core": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.4.0.tgz",
-      "integrity": "sha512-PH3jqjUp8fTIaRa0i6fjJxXJSR9yDwldH1Qw7nMDNAouL7txsrSM6BhrQEjcaZ2mwfU0PNx8tsFQ+2/nfNdR1w==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.4.1.tgz",
+      "integrity": "sha512-HPQ+9GMF+yhDDXNKPp6HGAIv2yVapKTI7WRs2aN3TT+RxQkbmgO+3JlcMvRL2/lu0RqTVWoYCIhmF9/H/zRL1A==",
       "requires": {
         "@aws-sdk/service-error-classification": "^3.4.1",
         "@aws-sdk/types": "^3.4.1",
@@ -14548,9 +15165,9 @@
       "dev": true
     },
     "codemaker": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.71.0.tgz",
-      "integrity": "sha512-kjpPxr5TRMYr2BG0EP9IEjQAeE6lTT9fybnCBxQdw3ebVoG8pvMshsQmoMwreL7IaloV8EYIkA+cfr/UpQ6CCg==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/codemaker/-/codemaker-1.75.0.tgz",
+      "integrity": "sha512-HGZQMJb+IXlGD5MJj6Ae2IXzkd4aoIufj/OfM0HxpJnldWx5rlzBjzgpI+YcK1RdaLm3HWMNDtTLti0qMsHtSA==",
       "dev": true,
       "requires": {
         "camelcase": "^6.3.0",
@@ -14625,9 +15242,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.159",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.159.tgz",
-      "integrity": "sha512-MXr+VXrNnyztGt06Y9reFd+m8vI0S/5/ogtgGQRCiwlz2XUjyTE02FuV4vYxSV8p1B2GY0DN9dubK/7DH5O3PQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.0.0.tgz",
+      "integrity": "sha512-MIwjmrXZpM9RtwyrSD4HotDIQl8HTdIefQhU+MU1asvtSyVN3kK8kjeUOWMFb+fdyT4RX3QvvcaaPBluLEX1SA==",
       "dev": true
     },
     "conventional-changelog-angular": {
@@ -14705,22 +15322,38 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.0.0.tgz",
+      "integrity": "sha512-da1EafcpH6b/TD8vDRaWV7xFINlHlF6zKsGwS1TsuVJTZRkquaS5HTMq7uq6h31619QjbsYl21gVDOm32KM1vQ==",
       "dev": true,
       "requires": {
-        "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
         "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        }
       }
     },
     "cosmiconfig-typescript-loader": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
-      "integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.3.0.tgz",
+      "integrity": "sha512-NTxV1MFfZDLPiBMjxbHRwSh5LaLcPMwNdCutmnHJCKoVnlvldPWlllonKwrsRJ5pYZBIBGRWWU2tfvzxgeSW5Q==",
       "dev": true,
       "requires": {}
     },
@@ -15017,14 +15650,80 @@
       "dev": true
     },
     "env-ci": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
-      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-8.0.0.tgz",
+      "integrity": "sha512-W+3BqGZozFua9MPeXpmTm5eYEBtGgL76jGu/pwMVp/L8PdECSCEWaIp7d4Mw7kuUrbUldK0oV0bNd6ZZjLiMiA==",
       "dev": true,
       "requires": {
-        "execa": "^5.0.0",
-        "fromentries": "^1.3.2",
-        "java-properties": "^1.0.0"
+        "execa": "^6.1.0",
+        "java-properties": "^1.0.2"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "human-signals": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        }
       }
     },
     "error-ex": {
@@ -15062,13 +15761,13 @@
       }
     },
     "eslint": {
-      "version": "8.27.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.27.0.tgz",
-      "integrity": "sha512-0y1bfG2ho7mty+SiILVf9PfuRA49ek4Nc60Wmmu62QlobNR+CeXa4xXIJgcuwSQgZiWaPH+5BDsctpIW0PR/wQ==",
+      "version": "8.34.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.34.0.tgz",
+      "integrity": "sha512-1Z8iFsucw+7kSqXNZVslXS8Ioa4u2KM7GPwuKtkTFAqZ/cHMcEaR+1+Br0wLlot49cNxIiZk5wp8EAbPcYZxTg==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.3.3",
-        "@humanwhocodes/config-array": "^0.11.6",
+        "@eslint/eslintrc": "^1.4.1",
+        "@humanwhocodes/config-array": "^0.11.8",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
         "ajv": "^6.10.0",
@@ -15087,7 +15786,7 @@
         "file-entry-cache": "^6.0.1",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.15.0",
+        "globals": "^13.19.0",
         "grapheme-splitter": "^1.0.4",
         "ignore": "^5.2.0",
         "import-fresh": "^3.0.0",
@@ -15153,9 +15852,9 @@
           }
         },
         "globals": {
-          "version": "13.17.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
-          "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
+          "version": "13.20.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.20.0.tgz",
+          "integrity": "sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -15439,18 +16138,19 @@
       }
     },
     "figures": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
-      "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-5.0.0.tgz",
+      "integrity": "sha512-ej8ksPF4x6e5wvK9yevct0UCXh8TTFlWGVLlgjZuoBH1HwjIfKE/IdL5mq89sFA7zELi1VhKpmtDnrs7zWyeyg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.5"
+        "escape-string-regexp": "^5.0.0",
+        "is-unicode-supported": "^1.2.0"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
           "dev": true
         }
       }
@@ -15484,12 +16184,12 @@
       }
     },
     "find-versions": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
-      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-5.1.0.tgz",
+      "integrity": "sha512-+iwzCJ7C5v5KgcBuueqVoNiHVoQpwiUK5XFLjf0affFTep+Wcw93tPvmb8tqujDNmzhBDPddnWV/qgWSXgq+Hg==",
       "dev": true,
       "requires": {
-        "semver-regex": "^3.1.2"
+        "semver-regex": "^4.0.5"
       }
     },
     "flat-cache": {
@@ -15536,12 +16236,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
-    },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
     },
     "fs-extra": {
       "version": "10.1.0",
@@ -15774,9 +16468,9 @@
       }
     },
     "hook-std": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-2.0.0.tgz",
-      "integrity": "sha512-zZ6T5WcuBMIUVh49iPQS9t977t7C0l7OtHrpeMb5uk48JdflRX0NSFvCekfYNmGQETnLq9W/isMyHl69kxGi8g==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hook-std/-/hook-std-3.0.0.tgz",
+      "integrity": "sha512-jHRQzjSDzMtFy34AGj1DN+vq54WVuhSvKgrHf0OMiFQTwDD4L/qqofVEWjLOBMTn5+lCD3fPg32W9yOfnEJTTw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -15831,9 +16525,9 @@
       "dev": true
     },
     "husky": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.2.tgz",
-      "integrity": "sha512-Tkv80jtvbnkK3mYWxPZePGFpQ/tT3HNSs/sasF9P2YfkMezDl3ON37YN6jUUI4eTg5LcyVynlb6r4eyvOmspvg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
     "iconv-lite": {
@@ -16079,6 +16773,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+      "dev": true
+    },
+    "is-unicode-supported": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
+      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "dev": true
     },
     "isarray": {
@@ -16721,18 +17421,18 @@
       "dev": true
     },
     "jsii": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.71.0.tgz",
-      "integrity": "sha512-Dn6TvKgMNEsMU/WKliSbVs93Cno238LZZeJTNXk9L6vOR3d7jjEsWh7PJ7NhdyZeft2M3RFJQDKhg8eKeKM/4g==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/jsii/-/jsii-1.75.0.tgz",
+      "integrity": "sha512-9CWt2IQcM6v5k4XZnaSnsK9epfIJfHWMyB69uOjITZpwYjF0CDzLrh/a8l1RyC3COSpp1K1yTjaebHEivyVr4Q==",
       "dev": true,
       "requires": {
-        "@jsii/check-node": "1.71.0",
-        "@jsii/spec": "^1.71.0",
+        "@jsii/check-node": "1.75.0",
+        "@jsii/spec": "^1.75.0",
         "case": "^1.6.3",
         "chalk": "^4",
         "fast-deep-equal": "^3.1.3",
         "fs-extra": "^10.1.0",
-        "log4js": "^6.7.0",
+        "log4js": "^6.7.1",
         "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "sort-json": "^2.0.1",
@@ -16749,24 +17449,30 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+          "dev": true
         }
       }
     },
     "jsii-pacmak": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.71.0.tgz",
-      "integrity": "sha512-IaAzJLcvE6fgr7PBjPm/mSb4RCmBT2Ecog8G352J/n15Vqu0vEByvsyK+kxF/ymGAEbODXVN0CV2HjxLQ5FdgA==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/jsii-pacmak/-/jsii-pacmak-1.75.0.tgz",
+      "integrity": "sha512-ENH5nNwMjN4CIK9D5mJ8OHDjiwInzQItQQmGwCdPJFLlUN9+9EkhYy2gEPVYPwh7e294c2nJ55DmiOj2CWR17g==",
       "dev": true,
       "requires": {
-        "@jsii/check-node": "1.71.0",
-        "@jsii/spec": "^1.71.0",
+        "@jsii/check-node": "1.75.0",
+        "@jsii/spec": "^1.75.0",
         "clone": "^2.1.2",
-        "codemaker": "^1.71.0",
+        "codemaker": "^1.75.0",
         "commonmark": "^0.30.0",
         "escape-string-regexp": "^4.0.0",
         "fs-extra": "^10.1.0",
-        "jsii-reflect": "^1.71.0",
-        "jsii-rosetta": "^1.71.0",
+        "jsii-reflect": "^1.75.0",
+        "jsii-rosetta": "^1.75.0",
         "semver": "^7.3.8",
         "spdx-license-list": "^6.6.0",
         "xmlbuilder": "^15.1.1",
@@ -16791,23 +17497,23 @@
       }
     },
     "jsii-reflect": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.71.0.tgz",
-      "integrity": "sha512-zaufJxtJi7X17bz0ya5Gp6TQ3m4/cbNSxvGboRo4dZGzz1Kaf4qXTlu08sN7NVM6ObTVeyp3atl1KLcf6MKIgw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/jsii-reflect/-/jsii-reflect-1.75.0.tgz",
+      "integrity": "sha512-oB8X2MpLZbpl8T7XfD+jSADLjzhEMnCZH8BSY3hxSH8TGdhMUZriFHFgmz1NshkZXDh0zRz+xF2a8+uqEIKRYw==",
       "dev": true,
       "requires": {
-        "@jsii/check-node": "1.71.0",
-        "@jsii/spec": "^1.71.0",
+        "@jsii/check-node": "1.75.0",
+        "@jsii/spec": "^1.75.0",
         "chalk": "^4",
         "fs-extra": "^10.1.0",
-        "oo-ascii-tree": "^1.71.0",
+        "oo-ascii-tree": "^1.75.0",
         "yargs": "^16.2.0"
       }
     },
     "jsii-release": {
-      "version": "0.2.521",
-      "resolved": "https://registry.npmjs.org/jsii-release/-/jsii-release-0.2.521.tgz",
-      "integrity": "sha512-OxAtMHTOmcVW2t5orlDeGsHT1iT4aFCqeu06DxMXPiAC4WZxOZ8JehIxsYDRZyMyyXBY3vd5AJTBgmElEoToPA==",
+      "version": "0.2.598",
+      "resolved": "https://registry.npmjs.org/jsii-release/-/jsii-release-0.2.598.tgz",
+      "integrity": "sha512-2dPz76WV8eNFU+OrMKeu/inbADI9DEeOeVeBpbKQDC150TA0nZ+z/04jcRuI/tbXoqm1fghCI3EgLL0bRgl4yA==",
       "dev": true,
       "requires": {
         "@types/fs-extra": "^8.0.0",
@@ -16844,21 +17550,21 @@
       }
     },
     "jsii-rosetta": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.71.0.tgz",
-      "integrity": "sha512-Iu36Dxpu1JphYnicmnPvS4AsqmeOwExjenVqmGJaIJwdMG6W9ou3WM1FoUa7LzenaJiFY9jj1CvbD05xgAo+ow==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/jsii-rosetta/-/jsii-rosetta-1.75.0.tgz",
+      "integrity": "sha512-zsV8F0BoXTvS46N1/QCwapMXamQhJKFaAIapFBWk0a4l84v+FSYOWnKbgZz+FVZEuu3VBJpxg6uKE9R9A8Hvag==",
       "dev": true,
       "requires": {
-        "@jsii/check-node": "1.71.0",
-        "@jsii/spec": "1.71.0",
-        "@xmldom/xmldom": "^0.8.5",
+        "@jsii/check-node": "1.75.0",
+        "@jsii/spec": "1.75.0",
+        "@xmldom/xmldom": "^0.8.6",
         "commonmark": "^0.30.0",
         "fast-glob": "^3.2.12",
-        "jsii": "1.71.0",
+        "jsii": "1.75.0",
         "semver": "^7.3.8",
         "semver-intersect": "^1.4.0",
         "typescript": "~3.9.10",
-        "workerpool": "^6.3.0",
+        "workerpool": "^6.3.1",
         "yargs": "^16.2.0"
       },
       "dependencies": {
@@ -16870,6 +17576,12 @@
           "requires": {
             "lru-cache": "^6.0.0"
           }
+        },
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+          "dev": true
         }
       }
     },
@@ -17028,6 +17740,18 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "dev": true
+    },
     "lodash.capitalize": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
@@ -17038,6 +17762,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
       "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "dev": true
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
       "dev": true
     },
     "lodash.ismatch": {
@@ -17058,6 +17788,12 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true
     },
+    "lodash.kebabcase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz",
+      "integrity": "sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -17070,16 +17806,46 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true
+    },
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
       "integrity": "sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==",
       "dev": true
     },
+    "lodash.upperfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz",
+      "integrity": "sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==",
+      "dev": true
+    },
     "log4js": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.0.tgz",
-      "integrity": "sha512-KA0W9ffgNBLDj6fZCq/lRbgR6ABAodRIDHrZnS48vOtfKa4PzWImb0Md1lmGCdO3n3sbCm/n1/WmrNlZ8kCI3Q==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.7.1.tgz",
+      "integrity": "sha512-lzbd0Eq1HRdWM2abSD7mk6YIVY0AogGJzb/z+lqzRk+8+XJP+M6L1MS5FUSc3jjGru4dbKjEMJmqlsoYYpuivQ==",
       "dev": true,
       "requires": {
         "date-format": "^4.0.14",
@@ -19256,9 +20022,9 @@
       }
     },
     "oo-ascii-tree": {
-      "version": "1.71.0",
-      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.71.0.tgz",
-      "integrity": "sha512-20AV6WE6Z9wUsmTmunnmSt7hDQCXWquYEtlkeITdHs4eGiZ/vgsf5E1TPyVLBpA6Nm0Dy9CXY87r83uotZLzbw==",
+      "version": "1.75.0",
+      "resolved": "https://registry.npmjs.org/oo-ascii-tree/-/oo-ascii-tree-1.75.0.tgz",
+      "integrity": "sha512-rM9YrFT0Zzes3nLF37sGJIlHIjLQpnEI17LcbioXw83oMHqdc8QW5pE9/IHkYlYRbN2Z+sRouSCkrXFZRai2Mg==",
       "dev": true
     },
     "optionator": {
@@ -19276,9 +20042,9 @@
       }
     },
     "p-each-series": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
-      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-3.0.0.tgz",
+      "integrity": "sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==",
       "dev": true
     },
     "p-filter": {
@@ -19841,9 +20607,9 @@
       }
     },
     "semantic-release": {
-      "version": "19.0.5",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.5.tgz",
-      "integrity": "sha512-NMPKdfpXTnPn49FDogMBi36SiBfXkSOJqCkk0E4iWOY1tusvvgBwqUmxTX1kmlT6kIYed9YwNKD1sfPpqa5yaA==",
+      "version": "20.1.0",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-20.1.0.tgz",
+      "integrity": "sha512-+9+n6RIr0Fz0F53cXrjpawxWlUg3O7/qr1jF9lrE+/v6WqwBrSWnavVHTPaf2WLerET2EngoqI0M4pahkKl6XQ==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^9.0.2",
@@ -19851,29 +20617,284 @@
         "@semantic-release/github": "^8.0.0",
         "@semantic-release/npm": "^9.0.0",
         "@semantic-release/release-notes-generator": "^10.0.0",
-        "aggregate-error": "^3.0.0",
-        "cosmiconfig": "^7.0.0",
+        "aggregate-error": "^4.0.1",
+        "cosmiconfig": "^8.0.0",
         "debug": "^4.0.0",
-        "env-ci": "^5.0.0",
-        "execa": "^5.0.0",
-        "figures": "^3.0.0",
-        "find-versions": "^4.0.0",
+        "env-ci": "^8.0.0",
+        "execa": "^6.1.0",
+        "figures": "^5.0.0",
+        "find-versions": "^5.1.0",
         "get-stream": "^6.0.0",
         "git-log-parser": "^1.2.0",
-        "hook-std": "^2.0.0",
-        "hosted-git-info": "^4.0.0",
-        "lodash": "^4.17.21",
-        "marked": "^4.0.10",
-        "marked-terminal": "^5.0.0",
+        "hook-std": "^3.0.0",
+        "hosted-git-info": "^6.0.0",
+        "lodash-es": "^4.17.21",
+        "marked": "^4.1.0",
+        "marked-terminal": "^5.1.1",
         "micromatch": "^4.0.2",
-        "p-each-series": "^2.1.0",
-        "p-reduce": "^2.0.0",
-        "read-pkg-up": "^7.0.0",
+        "p-each-series": "^3.0.0",
+        "p-reduce": "^3.0.0",
+        "read-pkg-up": "^9.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.3.2",
-        "semver-diff": "^3.1.1",
+        "semver-diff": "^4.0.0",
         "signale": "^1.2.1",
-        "yargs": "^16.2.0"
+        "yargs": "^17.5.1"
+      },
+      "dependencies": {
+        "aggregate-error": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
+          "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
+          "dev": true,
+          "requires": {
+            "clean-stack": "^4.0.0",
+            "indent-string": "^5.0.0"
+          }
+        },
+        "clean-stack": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
+          "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "5.0.0"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+          "dev": true
+        },
+        "execa": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-6.1.0.tgz",
+          "integrity": "sha512-QVWlX2e50heYJcCPG0iWtf8r0xjEYfz/OYLGDYH+IyjWezzPNxz63qNFOu0l4YftGWuizFVZHHs8PrLU5p2IDA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.3",
+            "get-stream": "^6.0.1",
+            "human-signals": "^3.0.1",
+            "is-stream": "^3.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^5.1.0",
+            "onetime": "^6.0.0",
+            "signal-exit": "^3.0.7",
+            "strip-final-newline": "^3.0.0"
+          }
+        },
+        "find-up": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+          "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^7.1.0",
+            "path-exists": "^5.0.0"
+          }
+        },
+        "hosted-git-info": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
+          "integrity": "sha512-r0EI+HBMcXadMrugk0GCQ+6BQV39PiWAZVfq7oIckeGiN7sjRGyQxPdft3nQekFTCQbYxLBH+/axZMeH8UX6+w==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^7.5.1"
+          },
+          "dependencies": {
+            "lru-cache": {
+              "version": "7.16.1",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.16.1.tgz",
+              "integrity": "sha512-9kkuMZHnLH/8qXARvYSjNvq8S1GYFFzynQTAfKeaJ0sIrR3PUPuu37Z+EiIANiZBvpfTf2B5y8ecDLSMWlLv+w==",
+              "dev": true
+            }
+          }
+        },
+        "human-signals": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-3.0.1.tgz",
+          "integrity": "sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+          "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+          "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^6.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+          "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+          "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+          "dev": true,
+          "requires": {
+            "path-key": "^4.0.0"
+          }
+        },
+        "onetime": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+          "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^4.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+          "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^4.0.0"
+          }
+        },
+        "p-reduce": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-3.0.0.tgz",
+          "integrity": "sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+          "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+          "dev": true
+        },
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
+          "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.1",
+            "normalize-package-data": "^3.0.2",
+            "parse-json": "^5.2.0",
+            "type-fest": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-9.1.0.tgz",
+          "integrity": "sha512-vaMRR1AC1nrd5CQM0PhlRsO5oc2AAigqr7cCrZ/MW/Rsaflz4RlgzkpL4qoU/z1F6wrbd85iFv1OQj/y5RdGvg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^6.3.0",
+            "read-pkg": "^7.1.0",
+            "type-fest": "^2.5.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "strip-final-newline": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+          "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "2.19.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+          "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.7.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.0.tgz",
+          "integrity": "sha512-dwqOPg5trmrre9+v8SUo2q/hAwyKoVfu8OC1xPHKJGNdxAvPl4sKxL4vBnh3bQz/ZvvGAFeA5H3ou2kcOY8sQQ==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        },
+        "yocto-queue": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
+          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
+          "dev": true
+        }
+      }
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-4.0.0.tgz",
+      "integrity": "sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.3.5"
       },
       "dependencies": {
         "semver": {
@@ -19885,21 +20906,6 @@
             "lru-cache": "^6.0.0"
           }
         }
-      }
-    },
-    "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-      "dev": true
-    },
-    "semver-diff": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
-      "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
-      "dev": true,
-      "requires": {
-        "semver": "^6.3.0"
       }
     },
     "semver-intersect": {
@@ -19920,9 +20926,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
-      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
+      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
       "dev": true
     },
     "shebang-command": {
@@ -20188,9 +21194,9 @@
       }
     },
     "streamroller": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.3.tgz",
-      "integrity": "sha512-CphIJyFx2SALGHeINanjFRKQ4l7x2c+rXYJ4BMq0gd+ZK0gi4VT8b+eHe2wi58x4UayBAKx4xtHpXT/ea1cz8w==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
       "dev": true,
       "requires": {
         "date-format": "^4.0.14",
@@ -20579,9 +21585,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true
     },
     "uglify-js": {
@@ -20906,12 +21912,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -29,33 +29,32 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@commitlint/cli": "^17.2.0",
-    "@commitlint/config-conventional": "^17.2.0",
-    "@semantic-release/changelog": "^6.0.1",
+    "@commitlint/cli": "^17.4.4",
+    "@commitlint/config-conventional": "^17.4.4",
+    "@semantic-release/changelog": "^6.0.2",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "@types/aws-lambda": "^8.10.108",
+    "@types/aws-lambda": "^8.10.110",
     "@types/jest": "^27.5.2",
-    "@types/node": "^18.11.9",
-    "@types/prettier": "2.6.0",
-    "@typescript-eslint/eslint-plugin": "^5.42.0",
-    "@typescript-eslint/parser": "^5.42.0",
-    "aws-cdk-lib": "2.50.0",
-    "constructs": "^10.0.0",
-    "eslint": "^8.26.0",
-    "husky": "^8.0.1",
+    "@types/node": "18.11.19",
+    "@typescript-eslint/eslint-plugin": "^5.52.0",
+    "@typescript-eslint/parser": "^5.52.0",
+    "aws-cdk-lib": "2.65.0",
+    "constructs": "10.0.0",
+    "eslint": "^8.34.0",
+    "husky": "^8.0.3",
     "is-ci": "^3.0.1",
     "jest": "^27.5.1",
-    "jsii": "^1.70.0",
-    "jsii-pacmak": "^1.70.0",
-    "jsii-release": "^0.2.515",
+    "jsii": "^1.75.0",
+    "jsii-pacmak": "^1.75.0",
+    "jsii-release": "^0.2.598",
     "mocked-env": "^1.3.5",
-    "semantic-release": "^19.0.5",
-    "ts-jest": "^27.1.4",
-    "typescript": "~3.9.7"
+    "semantic-release": "^20.1.0",
+    "ts-jest": "^27.1.5",
+    "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "aws-cdk-lib": "2.50.0",
+    "aws-cdk-lib": "2.65.0",
     "constructs": "^10.0.0"
   },
   "bundledDependencies": [
@@ -63,8 +62,8 @@
     "aws-xray-sdk-core"
   ],
   "dependencies": {
-    "aws-sdk": "^2.1074.0",
-    "aws-xray-sdk-core": "^3.3.1"
+    "aws-sdk": "^2.1318.0",
+    "aws-xray-sdk-core": "^3.4.1"
   },
   "stability": "experimental",
   "jsii": {


### PR DESCRIPTION
Unfortunately some dependencies use newer typescript definitions that jsii doesn't support yet.